### PR TITLE
fix: stop leaking processors with multiple invoke

### DIFF
--- a/docs/content/changelog.rst
+++ b/docs/content/changelog.rst
@@ -1,3 +1,6 @@
+- v3.1.3: Fix a bug with invocation when an event matches several filters.
+- v3.1.2: Fix an incorrect import.
+- v3.1.1: Relax pydantic requirements to help dependency management for downstream projects.
 - v3.1.0: Add error handling strategies for processors.
 - v3.0.1: Improve the import path for results.
 - v3.0.0:

--- a/src/event_processor/event_processor.py
+++ b/src/event_processor/event_processor.py
@@ -1,5 +1,6 @@
 """Contains the EventProcessor class."""
 import inspect
+from copy import copy
 from types import ModuleType
 from typing import Dict, Callable, Tuple, List, Union
 
@@ -103,7 +104,9 @@ class EventProcessor:
         for (filter_, rank), processors in self.processors.items():
             if filter_.matches(event):
                 if rank > highest_rank:
-                    matching, highest_rank = processors, rank
+                    # We take a copy here to avoid mutating the list of processors associated with a filter if we also
+                    # end up hitting the elif just below.
+                    matching, highest_rank = copy(processors), rank
                 elif rank == highest_rank:
                     matching.extend(processors)
 

--- a/src/tests/test_event_processor.py
+++ b/src/tests/test_event_processor.py
@@ -118,6 +118,29 @@ def test_invoke_calls_matching_processor(event_processor):
     assert called is True
 
 
+def test_invoke_calls_processors_once_per_invoke_with_multiple_matched_processors_and_all_matches_invocation_strategy():
+    event_processor = EventProcessor(invocation_strategy=InvocationStrategies.ALL_MATCHES)
+    filter_a = Exists("a")
+    filter_b = Exists("b")
+    a_calls = 0
+    b_calls = 0
+
+    @event_processor.processor(filter_a)
+    def a_test():
+        nonlocal a_calls
+        a_calls += 1
+
+    @event_processor.processor(filter_b)
+    def b_test():
+        nonlocal b_calls
+        b_calls += 1
+
+    event_processor.invoke({"a": 0, "b": 0})
+    event_processor.invoke({"a": 0, "b": 0})
+    assert a_calls == 2
+    assert b_calls == 2
+
+
 def test_invoke_raises_for_no_matching_processors(event_processor):
 
     with pytest.raises(InvocationError):


### PR DESCRIPTION
This commit fixes a bug where a processor would be invoked succesively
more and more times because the list of processors associated with a
given filter was accidentally mutated during the invocation.